### PR TITLE
tests: support multiple forks

### DIFF
--- a/tests/test_lido.py
+++ b/tests/test_lido.py
@@ -1,7 +1,7 @@
 from roles_royce import roles
 from roles_royce.protocols.eth import lido
 from roles_royce.constants import ETHAddr
-from .utils import web3_eth, local_node, accounts, get_balance, fork_unlock_account, create_simple_safe
+from .utils import web3_eth, local_node_eth, accounts, get_balance, create_simple_safe
 
 # Test safe
 AVATAR = "0xC01318baB7ee1f5ba734172bF7718b5DC6Ec90E1"
@@ -70,8 +70,8 @@ def test_claim_withdrawal():
                          "0000000000000000000000000000000000000000000000000000000000000023"
 
 
-def test_integration(local_node, accounts):
-    w3 = local_node
+def test_integration(local_node_eth, accounts):
+    w3 = local_node_eth.w3
     safe = create_simple_safe(w3, accounts[0])
     safe.send([lido.Deposit(eth_amount=1_000_000)])
     steth_balance = get_balance(w3, ETHAddr.stETH, safe.address)
@@ -113,7 +113,7 @@ def test_integration(local_node, accounts):
     amount_of_stETH, shares, owner, timestamp, is_finalized, is_claimed = statuses[0]
     assert is_finalized and not is_claimed
 
-    fork_unlock_account(w3, owner)
+    local_node_eth.unlock_account(owner)
     # TODO
     # claim = lido.ClaimWithdrawal(request_id=3002)
     # tx_hash = w3.eth.send_transaction({"to": claim.contract_address, "value": claim.value, "data": claim.data,

--- a/tests/test_maker.py
+++ b/tests/test_maker.py
@@ -1,5 +1,5 @@
 from roles_royce.protocols.eth import maker
-from .utils import (local_node, accounts, get_balance, steal_token, create_simple_safe, top_up_address)
+from .utils import (local_node_eth, accounts, get_balance, steal_token, create_simple_safe, top_up_address)
 from .roles import setup_common_roles, deploy_roles, apply_presets
 from roles_royce import roles
 from roles_royce.constants import ETHAddr
@@ -161,8 +161,8 @@ def test_exit_all_drs():
 #-----------------------------------------------------#
 """Integration Tests"""
 #-----------------------------------------------------#
-def test_integration_maker_cdp_module_proxy(local_node, accounts):
-    w3 = local_node
+def test_integration_maker_cdp_module_proxy(local_node_eth, accounts):
+    w3 = local_node_eth.w3
     safe = create_simple_safe(w3=w3, owner=accounts[0])
     roles_ctract = deploy_roles(avatar=safe.address, w3=w3)
     setup_common_roles(safe, roles_ctract)
@@ -266,8 +266,8 @@ def test_integration_maker_cdp_module_proxy(local_node, accounts):
     assert locked_gem == 0
 
 
-def test_integration_maker_cdp_module_proxy_bulk(local_node, accounts):
-    w3 = local_node
+def test_integration_maker_cdp_module_proxy_bulk(local_node_eth, accounts):
+    w3 = local_node_eth.w3
     safe = create_simple_safe(w3=w3, owner=accounts[0])
     roles_ctract = deploy_roles(avatar=safe.address, w3=w3)
     setup_common_roles(safe, roles_ctract)
@@ -375,8 +375,8 @@ def test_integration_maker_cdp_module_proxy_bulk(local_node, accounts):
     assert eth_balance == approx(1100_000_000_000_000_000_000)
 
 
-def test_integration_maker_cdp_module_no_proxy(local_node, accounts):
-    w3 = local_node
+def test_integration_maker_cdp_module_no_proxy(local_node_eth, accounts):
+    w3 = local_node_eth.w3
     safe = create_simple_safe(w3=w3, owner=accounts[0])
     roles_ctract = deploy_roles(avatar=safe.address, w3=w3)
     setup_common_roles(safe, roles_ctract)
@@ -568,8 +568,8 @@ def test_integration_maker_cdp_module_no_proxy(local_node, accounts):
     assert gem_balance == wad_gem
 
 
-def test_integration_maker_dsr_module_proxy(local_node, accounts):
-    w3 = local_node
+def test_integration_maker_dsr_module_proxy(local_node_eth, accounts):
+    w3 = local_node_eth.w3
     safe = create_simple_safe(w3=w3, owner=accounts[0])
     roles_ctract = deploy_roles(avatar=safe.address, w3=w3)
     setup_common_roles(safe, roles_ctract)
@@ -639,8 +639,8 @@ def test_integration_maker_dsr_module_proxy(local_node, accounts):
     assert pie == 0
 
 
-def test_integration_maker_dsr_module_no_proxy(local_node, accounts):
-    w3 = local_node
+def test_integration_maker_dsr_module_no_proxy(local_node_eth, accounts):
+    w3 = local_node_eth.w3
     safe = create_simple_safe(w3=w3, owner=accounts[0])
     roles_ctract = deploy_roles(avatar=safe.address, w3=w3)
     setup_common_roles(safe, roles_ctract)

--- a/tests/test_safe_and_roles.py
+++ b/tests/test_safe_and_roles.py
@@ -6,17 +6,16 @@ from eth_account import Account
 
 from roles_royce.protocols.eth import balancer, aura
 from roles_royce import roles, Chain
-from roles_royce.evm_utils import roles_abi, roles_bytecode, dai_abi, erc20_abi
+from roles_royce.evm_utils import roles_abi, roles_bytecode, dai_abi
 from roles_royce.utils import MULTISENDS
 from roles_royce.constants import ETHAddr
 from roles_royce.generic_method import TxData
-from .utils import (local_node, local_node_reset, accounts, ETH_LOCAL_NODE_URL, fork_unlock_account, create_simple_safe,
-                    get_balance, steal_token, SimpleSafe)
+from .utils import (local_node_eth, local_node_eth_reset, accounts, ETH_LOCAL_NODE_URL, create_simple_safe, get_balance, steal_token, SimpleSafe)
 from .roles import setup_common_roles, deploy_roles, apply_presets
 
 
-def test_safe_and_roles(local_node):
-    w3 = local_node
+def test_safe_and_roles(local_node_eth):
+    w3 = local_node_eth.w3
     ethereum_client = EthereumClient(ETH_LOCAL_NODE_URL)
 
     # test accounts are generated using the Mnemonic: "test test test test test test test test test test test junk"
@@ -58,7 +57,7 @@ def test_safe_and_roles(local_node):
     dai_decimals = dai_ctract.functions.decimals().call()
     dai_amount = 5 * (10 ** dai_decimals)
 
-    fork_unlock_account(w3, ADDRESS_WITH_LOTS_OF_TOKENS)
+    local_node_eth.unlock_account(ADDRESS_WITH_LOTS_OF_TOKENS)
     dai_ctract.functions.transfer(safe.address, dai_amount).transact({"from": ADDRESS_WITH_LOTS_OF_TOKENS})
     assert dai_ctract.functions.balanceOf(safe.address).call() == 5 * (10 ** dai_decimals)
 
@@ -137,8 +136,8 @@ def test_safe_and_roles(local_node):
                    TxData(contract_address=roles_ctract_address, data=assign_role_5)])
 
 
-def test_balancer_aura_withdraw(local_node, accounts):
-    w3 = local_node
+def test_balancer_aura_withdraw(local_node_eth, accounts):
+    w3 = local_node_eth.w3
     safe = create_simple_safe(w3=w3, owner=accounts[0])
     roles_ctract = deploy_roles(avatar=safe.address, w3=w3)
     setup_common_roles(safe, roles_ctract)
@@ -231,14 +230,13 @@ def test_balancer_aura_withdraw(local_node, accounts):
     assert bpt_balance == aura_balance == 0
 
 
-def test_simple_account_balance(local_node, accounts):
-    w3 = local_node
-
+def test_simple_account_balance(local_node_eth, accounts):
+    w3 = local_node_eth.w3
     assert w3.eth.get_balance(accounts[0].address) == 10000000000000000000000
 
 
-def test_build_operation(local_node, accounts):
-    w3 = local_node
+def test_build_operation(local_node_eth, accounts):
+    w3 = local_node_eth.w3
     safe = create_simple_safe(w3=w3, owner=accounts[0])
     roles_ctract = deploy_roles(avatar=safe.address, w3=w3)
     setup_common_roles(safe, roles_ctract)

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -1,12 +1,12 @@
 from roles_royce.protocols.eth import spark
 from roles_royce.constants import ETHAddr, Chain
-from .utils import local_node, accounts, get_balance, steal_token, create_simple_safe
+from .utils import local_node_eth, accounts, get_balance, steal_token, create_simple_safe
 from roles_royce.toolshed.protocol_utils.spark.utils import SparkUtils
 from decimal import Decimal
 
 
-def test_integration(local_node, accounts):
-    w3 = local_node
+def test_integration(local_node_eth, accounts):
+    w3 = local_node_eth.w3
     safe = create_simple_safe(w3, accounts[0])
 
     ADDRESS_WITH_LOTS_OF_GNO = "0x849D52316331967b6fF1198e5E32A0eB168D039d"

--- a/tests/toolshed/anti_liquidation/test_anti_liquidation_spark.py
+++ b/tests/toolshed/anti_liquidation/test_anti_liquidation_spark.py
@@ -1,8 +1,8 @@
 from pytest import approx
 from roles_royce.protocols.eth import spark
 from roles_royce.constants import ETHAddr
-from tests.utils import local_node, accounts, get_balance, get_allowance, steal_token, create_simple_safe, \
-    local_node_set_block, top_up_address, fork_unlock_account, web3_eth
+from tests.utils import local_node_eth, accounts, get_balance, get_allowance, steal_token, create_simple_safe, \
+    top_up_address, web3_eth
 from roles_royce.toolshed.anti_liquidation.spark.cdp import SparkCDPManager, CDPData
 from roles_royce import roles
 from roles_royce.toolshed.protocol_utils.spark.utils import SparkUtils, SparkToken
@@ -99,8 +99,8 @@ def test_spark_cdp_manager_get_delta(web3_eth):
     assert amount_to_repay == 509677655395144366484434
 
 
-def test_integration_spark_cdp(local_node, accounts):
-    w3 = local_node
+def test_integration_spark_cdp(local_node_eth, accounts):
+    w3 = local_node_eth.w3
 
     safe = create_simple_safe(w3, accounts[0])
 
@@ -155,10 +155,10 @@ def test_integration_spark_cdp(local_node, accounts):
     assert amount_to_repay == 0
 
 
-def test_integration_spark_cdp_roles_1(local_node):
-    w3 = local_node
+def test_integration_spark_cdp_roles_1(local_node_eth):
+    w3 = local_node_eth.w3
     block = 17837956
-    local_node_set_block(w3, block)
+    local_node_eth.set_block(block)
 
     avatar_safe_address = "0x849D52316331967b6fF1198e5E32A0eB168D039d"
     roles_mod_address = "0x1cFB0CD7B1111bf2054615C7C491a15C4A3303cc"
@@ -193,7 +193,7 @@ def test_integration_spark_cdp_roles_1(local_node):
                                     web3=w3)
     assert status_simulation
 
-    fork_unlock_account(w3, bot_address)
+    local_node_eth.unlock_account(bot_address)
 
     redeem_sDAI_tx = roles.build([redeem_sDAI], role=role, account=bot_address, roles_mod_address=roles_mod_address,
                                  web3=w3)
@@ -213,10 +213,10 @@ def test_integration_spark_cdp_roles_1(local_node):
     assert cdp.health_factor == approx(Decimal('3'))
 
 
-def test_integration_spark_cdp_roles_2(local_node, accounts):
-    w3 = local_node
+def test_integration_spark_cdp_roles_2(local_node_eth, accounts):
+    w3 = local_node_eth.w3
     block = 17837956
-    local_node_set_block(w3, block)
+    local_node_eth.set_block(block)
 
     avatar_safe_address = "0x849D52316331967b6fF1198e5E32A0eB168D039d"
     roles_mod_address = "0x1cFB0CD7B1111bf2054615C7C491a15C4A3303cc"
@@ -231,7 +231,8 @@ def test_integration_spark_cdp_roles_2(local_node, accounts):
         "data": calldata_to_assign_role,
         "value": "0"
     }
-    fork_unlock_account(w3, avatar_safe_address)
+
+    local_node_eth.unlock_account(avatar_safe_address)
     tx_hash = w3.eth.send_transaction(tx_to_assign_role)
     w3.eth.wait_for_transaction_receipt(tx_hash, timeout=5)
     bot_address = accounts[0].address
@@ -287,10 +288,10 @@ def test_integration_spark_cdp_roles_2(local_node, accounts):
     assert cdp.health_factor == approx(Decimal('3'))
 
 
-def test_integration_spark_cdp_roles_3(local_node, accounts):
-    w3 = local_node
+def test_integration_spark_cdp_roles_3(local_node_eth, accounts):
+    w3 = local_node_eth.w3
     block = 17837956
-    local_node_set_block(w3, block)
+    local_node_eth.set_block(block)
 
     avatar_safe_address = "0x849D52316331967b6fF1198e5E32A0eB168D039d"
     roles_mod_address = "0x1cFB0CD7B1111bf2054615C7C491a15C4A3303cc"
@@ -306,7 +307,7 @@ def test_integration_spark_cdp_roles_3(local_node, accounts):
         "data": calldata_to_assign_role,
         "value": "0"
     }
-    fork_unlock_account(w3, avatar_safe_address)
+    local_node_eth.unlock_account(avatar_safe_address)
     tx_hash = w3.eth.send_transaction(tx_to_assign_role)
     w3.eth.wait_for_transaction_receipt(tx_hash, timeout=5)
     private_key = accounts[0].key.hex()


### PR DESCRIPTION
This PR adds the ability to use eth and gnosis chain forks in simultaneous while also improve the functionality and ease adding more chains in the future.

Fixes #66 