### PR TITLE
chore: add info for gnosischain

### DIFF
--- a/roles_royce/toolshed/protocol_utils/spark/addresses_and_abis.py
+++ b/roles_royce/toolshed/protocol_utils/spark/addresses_and_abis.py
@@ -1,5 +1,5 @@
+from roles_royce.abi_utils import AddressOrAbi, load_abi
 from roles_royce.constants import Chain
-from roles_royce.abi_utils import load_abi, AddressOrAbi
 
 
 class EthereumAddressesAndAbis:
@@ -10,7 +10,13 @@ class EthereumAddressesAndAbis:
                             abi=load_abi('maker_pot.json'),
                             name='maker_pot')
 
+class GnosisChainAddressesAndAbis:
+    ProtocolDataProvider = AddressOrAbi(address='0x2a002054A06546bB5a264D57A81347e23Af91D18',
+                                        abi=load_abi('protocol_data_provider.json'),
+                                        name='protocol_data_provider')
 
 AddressesAndAbis = {
-    Chain.Ethereum: EthereumAddressesAndAbis
+    Chain.Ethereum: EthereumAddressesAndAbis,
+    Chain.GnosisChain: GnosisChainAddressesAndAbis
+
 }


### PR DESCRIPTION
there was this info missing for the addresses and abis , it was throwing errors when trying to query! 