### PR TITLE
Tweaks panic button

### DIFF
--- a/roles_royce/applications/panic_button_app/example.env
+++ b/roles_royce/applications/panic_button_app/example.env
@@ -7,8 +7,12 @@
 
 ENVIRONMENT = development
 
+# For development environment, name of the host running the local fork (e.g. with docker compose, the name of the
+#container running Anvil). If left empty it will default to 'localhost'
+LOCAL_FORK_HOST =
+
 # For development environment, ports running local forks of Ethereum and Gnosis. If left empty they will default
-# to 8546 and 8547, respetively
+# to 8546 and 8547, respectively
 LOCAL_FORK_PORT_ETHEREUM =
 LOCAL_FORK_PORT_GNOSIS =
 
@@ -29,11 +33,17 @@ SLACK_WEBHOOK_URL =
 
 
 #-----------------------------------------------------------------------------------------------------------------------
-# Ethereum (for dev environment fill in the DISASSEMBLER_ADDRESS while leaving PRIVATE_KEY empty)
+# Ethereum (for dev environment fill in the DISASSEMBLER_ADDRESS while leaving PRIVATE_KEY empty, for production
+# environment fill in the PRIVATE_KEY and DISASSEMBLER_ADDRESS can be left empty)
 #-----------------------------------------------------------------------------------------------------------------------
 
+# RPC endpoints for eth_call
 ETHEREUM_RPC_ENDPOINT =
-ETHEREUM_FALLBACK_RPC_ENDPOINT =
+ETHEREUM_RPC_ENDPOINT_FALLBACK =
+
+# RPC endpoint with MEV protection for eth_sendTransaction for the execution of transactions. If left empty
+# ETHEREUM_RPC_ENDPOINT will be used for the execution by default
+ETHEREUM_RPC_ENDPOINT_MEV =
 
 # Gnosis DAO
 GNOSISDAO_ETHEREUM_AVATAR_SAFE_ADDRESS =
@@ -50,11 +60,17 @@ GNOSISLTD_ETHEREUM_PRIVATE_KEY =
 GNOSISLTD_ETHEREUM_DISASSEMBLER_ADDRESS =
 
 #-----------------------------------------------------------------------------------------------------------------------
-# Gnosis (for dev environment fill in the DISASSEMBLER_ADDRESS while leaving PRIVATE_KEY empty)
+# Gnosis (for dev environment fill in the DISASSEMBLER_ADDRESS while leaving PRIVATE_KEY empty, for production
+# environment fill in the PRIVATE_KEY and DISASSEMBLER_ADDRESS can be left empty)
 #-----------------------------------------------------------------------------------------------------------------------
 
+# RPC endpoints for eth_call
 GNOSIS_RPC_ENDPOINT =
-GNOSIS_FALLBACK_RPC_ENDPOINT =
+GNOSIS_RPC_ENDPOINT_FALLBACK =
+
+# RPC endpoint with MEV protection for eth_sendTransaction for the execution of transactions. If left empty
+# GNOSIS_RPC_ENDPOINT will be used for the execution by default
+GNOSIS_RPC_ENDPOINT_MEV =
 
 # Gnosis DAO
 GNOSISDAO_GNOSIS_AVATAR_SAFE_ADDRESS =

--- a/roles_royce/applications/panic_button_app/example.env
+++ b/roles_royce/applications/panic_button_app/example.env
@@ -1,17 +1,17 @@
 #-----------------------------------------------------------------------------------------------------------------------
-# Dev or production environment
+# Dev or production environment mode
 # If set to 'development' transactions will be executed on a local fork, no private keys are needed
 # If set to 'production' transactions will be executed on the real blockchain, private keys are needed
 # If left empty it will default to 'development'
 #-----------------------------------------------------------------------------------------------------------------------
 
-ENVIRONMENT = development
+MODE = development
 
-# For development environment, name of the host running the local fork (e.g. with docker compose, the name of the
-#container running Anvil). If left empty it will default to 'localhost'
+# For development mode, name of the host running the local fork (e.g. with docker compose, the name of the
+# container running Anvil). If left empty it will default to 'localhost'
 LOCAL_FORK_HOST =
 
-# For development environment, ports running local forks of Ethereum and Gnosis. If left empty they will default
+# For development mode, ports running local forks of Ethereum and Gnosis. If left empty they will default
 # to 8546 and 8547, respectively
 LOCAL_FORK_PORT_ETHEREUM =
 LOCAL_FORK_PORT_GNOSIS =
@@ -33,8 +33,8 @@ SLACK_WEBHOOK_URL =
 
 
 #-----------------------------------------------------------------------------------------------------------------------
-# Ethereum (for dev environment fill in the DISASSEMBLER_ADDRESS while leaving PRIVATE_KEY empty, for production
-# environment fill in the PRIVATE_KEY and DISASSEMBLER_ADDRESS can be left empty)
+# Ethereum (for devevelopment mode fill in the DISASSEMBLER_ADDRESS while leaving PRIVATE_KEY empty, for production
+# mode fill in the PRIVATE_KEY and DISASSEMBLER_ADDRESS can be left empty)
 #-----------------------------------------------------------------------------------------------------------------------
 
 # RPC endpoints for eth_call
@@ -60,8 +60,8 @@ GNOSISLTD_ETHEREUM_PRIVATE_KEY =
 GNOSISLTD_ETHEREUM_DISASSEMBLER_ADDRESS =
 
 #-----------------------------------------------------------------------------------------------------------------------
-# Gnosis (for dev environment fill in the DISASSEMBLER_ADDRESS while leaving PRIVATE_KEY empty, for production
-# environment fill in the PRIVATE_KEY and DISASSEMBLER_ADDRESS can be left empty)
+# Gnosis (for development mode fill in the DISASSEMBLER_ADDRESS while leaving PRIVATE_KEY empty, for production
+# mode fill in the PRIVATE_KEY and DISASSEMBLER_ADDRESS can be left empty)
 #-----------------------------------------------------------------------------------------------------------------------
 
 # RPC endpoints for eth_call

--- a/roles_royce/applications/panic_button_app/panic_button_main.py
+++ b/roles_royce/applications/panic_button_app/panic_button_main.py
@@ -2,7 +2,7 @@ import argparse
 from web3 import Web3
 from roles_royce.toolshed.disassembling import AuraDisassembler, BalancerDisassembler, Disassembler
 from roles_royce.utils import TenderlyCredentials
-from roles_royce.applications.panic_button_app.utils import ENV, ExecConfig, Environment, fork_unlock_account, \
+from roles_royce.applications.panic_button_app.utils import ENV, ExecConfig, Modes, fork_unlock_account, \
     top_up_address
 import time
 from roles_royce.generic_method import Transactable
@@ -11,7 +11,7 @@ import json
 
 
 def start_the_engine(env: ENV) -> (Web3, Web3):
-    if env.ENVIRONMENT == Environment.DEVELOPMENT:
+    if env.MODE == Modes.DEVELOPMENT:
         w3 = Web3(Web3.HTTPProvider(f'http://{env.LOCAL_FORK_HOST}:{env.LOCAL_FORK_PORT}'))
         fork_unlock_account(w3, env.DISASSEMBLER_ADDRESS)
         top_up_address(w3, env.DISASSEMBLER_ADDRESS, 1)  # Topping up disassembler address for testing
@@ -86,7 +86,7 @@ def drive_away(disassembler: Disassembler, txn_transactables: list[Transactable]
                                                    from_address=env.DISASSEMBLER_ADDRESS)
 
                 if check_exit_tx:
-                    if env.ENVIRONMENT == 'production':  # In production environment, send the transaction to the real blockchain
+                    if env.MODE == 'production':  # In production environment, send the transaction to the real blockchain
                         if w3 is None:
                             w3 = disassembler.w3  # Overriding of the w3 instance for MEV protection
                         tx_receipt = disassembler.send(txns=txn_transactables, private_key=env.PRIVATE_KEY, w3=w3)
@@ -112,8 +112,7 @@ def drive_away(disassembler: Disassembler, txn_transactables: list[Transactable]
             return response_message
 
     else:
-        return {"status": 200, "link": "No link", "message": "No transactions need to be executed for the desired "
-                                                             "outcome"}
+        return {"status": 200, "link": "No link", "message": "There are no funds in the position, no transaction needs to be executed"}
 
 
 def main():

--- a/roles_royce/applications/panic_button_app/utils.py
+++ b/roles_royce/applications/panic_button_app/utils.py
@@ -32,20 +32,29 @@ class ENV:
     TENDERLY_API_TOKEN: str = field(init=False)
 
     RPC_ENDPOINT: str = field(init=False)
-    FALLBACK_RPC_ENDPOINT: str = field(init=False)
+    RPC_ENDPOINT_FALLBACK: str = field(init=False)
+    RPC_ENDPOINT_MEV: str = field(init=False)
+
     AVATAR_SAFE_ADDRESS: Address = field(init=False)
     ROLES_MOD_ADDRESS: Address = field(init=False)
     ROLE: int = field(init=False)
     PRIVATE_KEY: str = field(init=False)
-    SLACK_WEBHOOK_URL: str = field(init=False)
     DISASSEMBLER_ADDRESS: Address = field(init=False)
+
     ENVIRONMENT: Environment = field(init=False)
     LOCAL_FORK_PORT: int | None = field(init=False)
+    LOCAL_FORK_HOST: str = field(init=False)
+
+    SLACK_WEBHOOK_URL: str = field(init=False)
+
 
     def __post_init__(self):
+        # Tenderly credentials
         self.TENDERLY_ACCOUNT_ID: str = config('TENDERLY_ACCOUNT_ID', default='')
         self.TENDERLY_PROJECT: str = config('TENDERLY_PROJECT', default='')
         self.TENDERLY_API_TOKEN: str = config('TENDERLY_API_TOKEN', default='')
+
+        # DAO and blockchain
         if self.DAO not in ['GnosisDAO', 'GnosisLTD']:
             raise ValueError(f"DAO is not valid: {self.DAO}.")
         if self.BLOCKCHAIN.lower() not in ['mainnet', 'ethereum', 'gnosis']:
@@ -53,15 +62,20 @@ class ENV:
         elif self.BLOCKCHAIN.lower() == 'mainnet':
             self.BLOCKCHAIN = 'ethereum'
         self.BLOCKCHAIN = self.BLOCKCHAIN.lower()
+
+        # RPC endpoints
         self.RPC_ENDPOINT: str = config(self.BLOCKCHAIN.upper() + '_RPC_ENDPOINT', default='')
-        self.FALLBACK_RPC_ENDPOINT: str = config(self.BLOCKCHAIN.upper() + '_FALLBACK_RPC_ENDPOINT', default='')
+        self.RPC_ENDPOINT_FALLBACK: str = config(self.BLOCKCHAIN.upper() + '_RPC_ENDPOINT_FALLBACK', default='')
+        self.RPC_ENDPOINT_FALLBACK: str = config(self.BLOCKCHAIN.upper() + '_RPC_ENDPOINT_MEV', default='')
+
+
+        # Configuration addresses and key
         self.AVATAR_SAFE_ADDRESS: Address = config(
             self.DAO.upper() + '_' + self.BLOCKCHAIN.upper() + '_AVATAR_SAFE_ADDRESS', default='')
         self.ROLES_MOD_ADDRESS: Address = config(
             self.DAO.upper() + '_' + self.BLOCKCHAIN.upper() + '_ROLES_MOD_ADDRESS', default='')
         self.ROLE: int = config(self.DAO.upper() + '_' + self.BLOCKCHAIN.upper() + '_ROLE', cast=int, default=0)
         self.PRIVATE_KEY: str = config(self.DAO.upper() + '_' + self.BLOCKCHAIN.upper() + '_PRIVATE_KEY', default='')
-        self.SLACK_WEBHOOK_URL: str = config('SLACK_WEBHOOK_URL', default='')
         self.AVATAR_SAFE_ADDRESS = Web3.to_checksum_address(self.AVATAR_SAFE_ADDRESS)
         self.ROLES_MOD_ADDRESS = Web3.to_checksum_address(self.ROLES_MOD_ADDRESS)
         if self.PRIVATE_KEY != '':
@@ -69,6 +83,8 @@ class ENV:
         else:
             self.DISASSEMBLER_ADDRESS = config(
                 self.DAO.upper() + '_' + self.BLOCKCHAIN.upper() + '_DISASSEMBLER_ADDRESS', default='')
+
+        # Environment: development or production
         self.ENVIRONMENT: Environment = custom_config('ENVIRONMENT', cast=Environment, default=Environment.DEVELOPMENT)
         if self.ENVIRONMENT.lower() not in ['development', 'production']:
             raise ValueError(
@@ -82,6 +98,8 @@ class ENV:
                 self.LOCAL_FORK_PORT = custom_config('LOCAL_FORK_PORT_GNOSIS', cast=int, default=8547)
         else:
             self.LOCAL_FORK_PORT = None
+        self.LOCAL_FORK_HOST: str = custom_config('LOCAL_FORK_HOST', default='localhost', cast=str)
+
         self.SLACK_WEBHOOK_URL: str = config('SLACK_WEBHOOK_URL', default='')
 
     def __repr__(self):

--- a/roles_royce/applications/panic_button_app/utils.py
+++ b/roles_royce/applications/panic_button_app/utils.py
@@ -9,7 +9,7 @@ from roles_royce.constants import StrEnum
 from web3.exceptions import ContractLogicError
 
 
-class Environment(StrEnum):
+class Modes(StrEnum):
     DEVELOPMENT = 'development'
     PRODUCTION = 'production'
 
@@ -41,7 +41,7 @@ class ENV:
     PRIVATE_KEY: str = field(init=False)
     DISASSEMBLER_ADDRESS: Address = field(init=False)
 
-    ENVIRONMENT: Environment = field(init=False)
+    MODE: Modes = field(init=False)
     LOCAL_FORK_PORT: int | None = field(init=False)
     LOCAL_FORK_HOST: str = field(init=False)
 
@@ -84,14 +84,14 @@ class ENV:
             self.DISASSEMBLER_ADDRESS = config(
                 self.DAO.upper() + '_' + self.BLOCKCHAIN.upper() + '_DISASSEMBLER_ADDRESS', default='')
 
-        # Environment: development or production
-        self.ENVIRONMENT: Environment = custom_config('ENVIRONMENT', cast=Environment, default=Environment.DEVELOPMENT)
-        if self.ENVIRONMENT.lower() not in ['development', 'production']:
+        # Environment mode: development or production
+        self.MODE: Modes = custom_config('ENVIRONMENT', cast=Modes, default=Modes.DEVELOPMENT)
+        if self.MODE.lower() not in ['development', 'production']:
             raise ValueError(
-                f"ENVIRONMENT is not valid: {self.ENVIRONMENT}. Options are either 'development' or 'production'.")
+                f"ENVIRONMENT is not valid: {self.MODE}. Options are either 'development' or 'production'.")
         else:
-            self.ENVIRONMENT = self.ENVIRONMENT.lower()
-        if self.ENVIRONMENT == Environment.DEVELOPMENT:
+            self.MODE = self.MODE.lower()
+        if self.MODE == Modes.DEVELOPMENT:
             if self.BLOCKCHAIN == 'ethereum':
                 self.LOCAL_FORK_PORT = custom_config('LOCAL_FORK_PORT_ETHEREUM', cast=int, default=8546)
             else:

--- a/roles_royce/toolshed/disassembling/disassembler.py
+++ b/roles_royce/toolshed/disassembling/disassembler.py
@@ -59,21 +59,25 @@ class Disassembler:
                                                   simulation_id=sim_data['simulation']['id'])
         return sim_data, simulate_link
 
-    def send(self, txns: list[Transactable], private_key: str) -> TxReceipt:
+    def send(self, txns: list[Transactable], private_key: str, w3: Web3 = None) -> TxReceipt:
         """Execute the multisend batched transactions.
 
         Args:
             txns (list[Transactable]): List of transactions to execute
             private_key (str): Private key of the account to execute the transactions from
+            w3 (Web3): Web3 instance to execute the transactions from that would override the self.w3 instance if w3 is
+                not None. Useful for nodes with MEV protection to be used only for eth_sendTransaction. Defaults to None
 
         Returns:
             TxReceipt: Transaction receipt
         """
+        if w3 is None:
+            w3 = self.w3
         return roles.send(txns,
                           role=self.role,
                           private_key=private_key,
                           roles_mod_address=self.roles_mod_address,
-                          web3=self.w3)
+                          web3=w3)
 
     def check(self, txns: list[Transactable], block: int | str = 'latest', from_address: Address | ChecksumAddress | str | None = None) -> TxParams:
         """Checks the multisend batched transactions with static call.

--- a/tests/applications/panic_button_app/test_main.py
+++ b/tests/applications/panic_button_app/test_main.py
@@ -1,5 +1,5 @@
 from roles_royce.applications.panic_button_app.panic_button_main import start_the_engine, gear_up, drive_away
-from roles_royce.applications.panic_button_app.utils import ENV, ExecConfig, Environment
+from roles_royce.applications.panic_button_app.utils import ENV, ExecConfig, Modes
 from tests.utils import assign_role, local_node_eth, accounts, fork_unlock_account
 import os
 import json
@@ -16,12 +16,12 @@ role = 4
 
 def set_env(monkeypatch, private_key: str) -> ENV:
     monkeypatch.setenv('ETHEREUM_RPC_ENDPOINT', 'DummyString')
-    monkeypatch.setenv('ETHEREUM_FALLBACK_RPC_ENDPOINT', 'DummyString')
+    monkeypatch.setenv('ETHEREUM_RPC_ENDPOINT_FALLBACK', 'DummyString')
     monkeypatch.setenv('GNOSISDAO_ETHEREUM_AVATAR_SAFE_ADDRESS', avatar_safe_address)
     monkeypatch.setenv('GNOSISDAO_ETHEREUM_ROLES_MOD_ADDRESS', roles_mod_address)
     monkeypatch.setenv('GNOSISDAO_ETHEREUM_ROLE', role)
     monkeypatch.setenv('GNOSISDAO_ETHEREUM_PRIVATE_KEY', private_key)
-    # Without setting the ENVIRONMENT env it will default to DEVELOPMENT and use the local fork
+    # Without setting the MODE env it will default to DEVELOPMENT and use the local fork
     return ENV(dao, blockchain)
 
 
@@ -64,10 +64,10 @@ exec_config = ExecConfig(percentage=JSON_FORM["percentage"],
 def test_start_the_engine(monkeypatch):
     env = set_env(monkeypatch, "0x0000000000000000000000000000000000000000000000000000000000000000")
 
-    w3,w3_MEV = start_the_engine(env)
+    w3, w3_MEV = start_the_engine(env)
     assert w3.is_connected()
 
-    env.ENVIRONMENT = Environment.PRODUCTION
+    env.MODE = Modes.PRODUCTION
     with pytest.raises(Exception):
         start_the_engine(env)  # RPC endpoints are 'DummyString'
 

--- a/tests/applications/panic_button_app/test_main.py
+++ b/tests/applications/panic_button_app/test_main.py
@@ -64,7 +64,7 @@ exec_config = ExecConfig(percentage=JSON_FORM["percentage"],
 def test_start_the_engine(monkeypatch):
     env = set_env(monkeypatch, "0x0000000000000000000000000000000000000000000000000000000000000000")
 
-    w3 = start_the_engine(env)
+    w3,w3_MEV = start_the_engine(env)
     assert w3.is_connected()
 
     env.ENVIRONMENT = Environment.PRODUCTION

--- a/tests/applications/panic_button_app/test_stresstest.py
+++ b/tests/applications/panic_button_app/test_stresstest.py
@@ -53,7 +53,7 @@ def set_env(monkeypatch, private_key: str) -> ENV:
     return ENV(dao, blockchain)
 
 
-@pytest.mark.skipif(not os.environ.get("RR_RUN_STRESSTEST", False), reason="Long position integration test not running by default.")
+#@pytest.mark.skipif(not os.environ.get("RR_RUN_STRESSTEST", False), reason="Long position integration test not running by default.")
 @pytest.mark.parametrize("exec_config", exec_configs)
 def test_stresstest(local_node_eth, accounts, monkeypatch, exec_config):
     private_key = set_up_roles(local_node_eth, accounts)
@@ -85,4 +85,4 @@ def test_stresstest(local_node_eth, accounts, monkeypatch, exec_config):
     assert main.returncode == 0
     dict_message_stdout = json.loads(main.stdout[:-1].replace("\'", "\""))
     assert dict_message_stdout['status'] == 200
-    assert dict_message_stdout['message'] == "Transaction executed successfully" or dict_message_stdout['message'] == 'No transactions need to be executed for the desired outcome'
+    assert dict_message_stdout['message'] == "Transaction executed successfully" or dict_message_stdout['message'] == 'There are no funds in the position, no transaction needs to be executed'

--- a/tests/applications/panic_button_app/test_stresstest.py
+++ b/tests/applications/panic_button_app/test_stresstest.py
@@ -53,7 +53,7 @@ def set_env(monkeypatch, private_key: str) -> ENV:
     return ENV(dao, blockchain)
 
 
-#@pytest.mark.skipif(not os.environ.get("RR_RUN_STRESSTEST", False), reason="Long position integration test not running by default.")
+@pytest.mark.skipif(not os.environ.get("RR_RUN_STRESSTEST", False), reason="Long position integration test not running by default.")
 @pytest.mark.parametrize("exec_config", exec_configs)
 def test_stresstest(local_node_eth, accounts, monkeypatch, exec_config):
     private_key = set_up_roles(local_node_eth, accounts)


### PR DESCRIPTION
Added:
- changed the name ENVIRONMENT for MODE in the env variables
- env variable for the host running Anvil (e.g. localhost or name of docker container)
- functionality so that while the eth_call calls can be made with some default RPC endpoint, the eth_sendTransaction call can be made with another, the RPC_ENDPOINT_MEV; intended to use an endpoint with MEV protection only for the execution of transactions and not to flood it with eth_call calls  