### PR TITLE
Revert removing the duplicated roles_royce directory

### DIFF
--- a/docker/Dockerfile.eur
+++ b/docker/Dockerfile.eur
@@ -22,6 +22,7 @@ WORKDIR /app
 # Copy the installed code from the build stage
 COPY --from=builder /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
+COPY roles_royce ./roles_royce
 COPY tests tests
 
 ENV PYTHONPATH=.

--- a/docker/Dockerfile.keeper
+++ b/docker/Dockerfile.keeper
@@ -22,6 +22,7 @@ WORKDIR /app
 # Copy the installed code from the build stage
 COPY --from=builder /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
+COPY roles_royce ./roles_royce
 COPY tests tests
 
 ENV PYTHONPATH=.

--- a/docker/Dockerfile.spark
+++ b/docker/Dockerfile.spark
@@ -22,6 +22,7 @@ WORKDIR /app
 # Copy the installed code from the build stage
 COPY --from=builder /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
+COPY roles_royce ./roles_royce
 COPY tests tests
 
 ENV PYTHONPATH=.


### PR DESCRIPTION
As the roles_royce directory is installed to /usr/local/lib/python3.10/site-packages I removed the directory to not have it twice but I did not note that it was used to launch the bots.