### PR TITLE
Split karpatkit dependency into the optional-dependencies "all"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
+          pip install . 'rolesroyce[all]'
           pip install -r requirements-dev.txt
       - name: Try anvil
         run: anvil --version

--- a/.github/workflows/json-update.yml
+++ b/.github/workflows/json-update.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install web3
-          pip3 install -e .
+          pip3 install -e . 'rolesroyce[all]'
           pip3 install --upgrade setuptools
 
       - name: Run Python script

--- a/README.md
+++ b/README.md
@@ -35,10 +35,29 @@ status = roles.send([claim],
 
 ```
 
+## Install
+
+When using `roleroyce` as a library, you have two way to install it:
+```sh
+pip install . 'roleroyce[all]'
+```
+or, if you experiment dependencies conflicts, you can take control over some dependencies version by removing `[all]`
+but specifying each missing dependencie.
+```sh
+pip install . 'roleroyce'
+pip install "karpatkit @ git+https://github.com/karpatkey/karpatkit.git@another_specific_version"
+```
+where `another_specific_version` should be a git reference (tag, hash, branch).
+
+Have a look `all` in the [pyproject.toml](pyproject.toml) file, `[project.optional-dependencies]` section.
+
+> Take into account that installing just `roleroyce` without `roleroyce[all]` is an incompleted instalation.
+
+
 ## Development
 
 * Install the python dev dependencies: `pip install -r requirements-dev.txt`
-* Install rolls_royce in editable mode: `pip install -e .`
+* Install rolls_royce in editable mode: `pip install -e . 'rolesroyce[all]'`
 * Install anvil by downloading it from https://github.com/foundry-rs/foundry.
 
 To run the tests start anvil in a terminal in fork mode on ports 8546 and 8547 with:

--- a/README.md
+++ b/README.md
@@ -37,21 +37,21 @@ status = roles.send([claim],
 
 ## Install
 
-When using `roleroyce` as a library, you have two way to install it:
+When using `rolesroyce` as a library, you have two way to install it:
 ```sh
-pip install . 'roleroyce[all]'
+pip install . 'rolesroyce[all]'
 ```
 or, if you experiment dependencies conflicts, you can take control over some dependencies version by removing `[all]`
 but specifying each missing dependencie.
 ```sh
-pip install . 'roleroyce'
+pip install . 'rolesroyce'
 pip install "karpatkit @ git+https://github.com/karpatkey/karpatkit.git@another_specific_version"
 ```
 where `another_specific_version` should be a git reference (tag, hash, branch).
 
 Have a look `all` in the [pyproject.toml](pyproject.toml) file, `[project.optional-dependencies]` section.
 
-> Take into account that installing just `roleroyce` without `roleroyce[all]` is an incompleted instalation.
+> Take into account that installing just `rolesroyce` without `rolesroyce[all]` is an incompleted instalation.
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -37,19 +37,19 @@ status = roles.send([claim],
 
 ## Install
 
-When using `rolesroyce` as a library, you have two way to install it:
+When using `rolesroyce` as a library, you have two ways to install it:
 ```sh
 pip install . 'rolesroyce[all]'
 ```
 or, if you experiment dependencies conflicts, you can take control over some dependencies version by removing `[all]`
-but specifying each missing dependencie.
+but specifying each missing dependency.
 ```sh
 pip install . 'rolesroyce'
 pip install "karpatkit @ git+https://github.com/karpatkey/karpatkit.git@another_specific_version"
 ```
 where `another_specific_version` should be a git reference (tag, hash, branch).
 
-Have a look `all` in the [pyproject.toml](pyproject.toml) file, `[project.optional-dependencies]` section.
+Have a look at `all` in the [pyproject.toml](pyproject.toml) file, `[project.optional-dependencies]` section.
 
 > Take into account that installing just `rolesroyce` without `rolesroyce[all]` is an incompleted instalation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,12 @@ dependencies = [
   "pydantic>=2.5.0,<3.0",
   "requests>=2.31.0,<3.0",
   "python-decouple>=3.8",
-  "karpatkit @ git+https://github.com/karpatkey/karpatkit.git@e40513b28e17a3d2983582a80e49ee841083ea76",
   "joblib>=1.3.2",
+]
+
+[project.optional-dependencies]
+all = [ # Put here all the dependencies with a strict version.
+  "karpatkit @ git+https://github.com/karpatkey/karpatkit.git@e40513b28e17a3d2983582a80e49ee841083ea76",
 ]
 
 [project.urls]


### PR DESCRIPTION
This is to have more flexibility when using this repo from another which has dependency conflicts.