### PR TITLE
Fix imports for AxA

### DIFF
--- a/roles_royce/applications/execution_app/http_server.py
+++ b/roles_royce/applications/execution_app/http_server.py
@@ -1,8 +1,8 @@
 from fastapi import FastAPI, Response
 from pydantic import BaseModel
 
-from .simulate import simulate as simulate_tx
-from .transaction_builder import build_transaction, transaction_check
+from roles_royce.applications.execution_app.simulate import simulate as simulate_tx
+from roles_royce.applications.execution_app.transaction_builder import build_transaction, transaction_check
 
 app = FastAPI()
 

--- a/roles_royce/applications/execution_app/simulate.py
+++ b/roles_royce/applications/execution_app/simulate.py
@@ -2,9 +2,8 @@ import argparse
 import json
 import traceback
 
+from roles_royce.applications.execution_app.utils import ENV, start_the_engine
 from roles_royce.toolshed.simulation import TenderlyCredentials, simulate_tx
-
-from .utils import ENV, start_the_engine
 
 
 def simulate(dao, blockchain, transaction, rpc_url: str | None = None):

--- a/roles_royce/applications/execution_app/stresstest.py
+++ b/roles_royce/applications/execution_app/stresstest.py
@@ -11,10 +11,10 @@ from defabipedia.types import Chain
 from joblib import Parallel, delayed
 from web3 import Web3
 
-from .execute import execute_env
-from .pulley_fork import PulleyFork
-from .transaction_builder import build_transaction_env
-from .utils import ENV, recovery_mode_balancer, start_the_engine
+from roles_royce.applications.execution_app.execute import execute_env
+from roles_royce.applications.execution_app.pulley_fork import PulleyFork
+from roles_royce.applications.execution_app.transaction_builder import build_transaction_env
+from roles_royce.applications.execution_app.utils import ENV, recovery_mode_balancer, start_the_engine
 
 logging.basicConfig(
     level=logging.INFO,

--- a/roles_royce/applications/execution_app/transaction_builder.py
+++ b/roles_royce/applications/execution_app/transaction_builder.py
@@ -5,10 +5,16 @@ import traceback
 
 from web3 import Web3
 
+from roles_royce.applications.execution_app.code_transporter import CodeTransporter
+from roles_royce.applications.execution_app.utils import (
+    ENV,
+    ExecConfig,
+    decode_transaction,
+    disassembler_from_config,
+    gear_up,
+    start_the_engine,
+)
 from roles_royce.roles_modifier import ROLES_V1_ERRORS, GasStrategies, set_gas_strategy
-
-from .code_transporter import CodeTransporter
-from .utils import ENV, ExecConfig, decode_transaction, disassembler_from_config, gear_up, start_the_engine
 
 
 def transaction_check(dao, blockchain, protocol, tx_transactables: str, rpc_url: str | None = None):


### PR DESCRIPTION
Don't use relative imports while relying on direct script exec
We can use relative imports when fully switched to http server