### PR TITLE
fix bug with amounts with multiple exit arguments/pools

### DIFF
--- a/roles_royce/toolshed/disassembling/disassembling_balancer.py
+++ b/roles_royce/toolshed/disassembling/disassembling_balancer.py
@@ -278,7 +278,7 @@ class BalancerDisassembler(Disassembler):
             withdraw_balancer = self.exit_1_1(
                 percentage=fraction,
                 exit_arguments=[{"bpt_address": bpt_address, "max_slippage": max_slippage}],
-                amount_to_redeem=amount_to_redeem,
+                amount_to_redeem=amount,
             )
             for transactable in withdraw_balancer:
                 txns.append(transactable)
@@ -333,7 +333,7 @@ class BalancerDisassembler(Disassembler):
                 exit_arguments=[
                     {"bpt_address": bpt_address, "token_out_address": token_out_address, "max_slippage": max_slippage}
                 ],
-                amount_to_redeem=amount_to_redeem,
+                amount_to_redeem=amount,
             )
             for transactable in withdraw_balancer:
                 txns.append(transactable)
@@ -379,7 +379,7 @@ class BalancerDisassembler(Disassembler):
             bpt_address = gauge_contract.functions.lp_token().call()
 
             withdraw_balancer = self.exit_1_3(
-                percentage=fraction, exit_arguments=[{"bpt_address": bpt_address}], amount_to_redeem=amount_to_redeem
+                percentage=fraction, exit_arguments=[{"bpt_address": bpt_address}], amount_to_redeem=amount
             )
             for transactable in withdraw_balancer:
                 txns.append(transactable)


### PR DESCRIPTION
- amount_to_redeem was being set on the method scope, causing it to use the first amount for all positions/pools
- In the future we should maybe have as part of exit_arguments
- not fixed possible same bug on Aura disassembler